### PR TITLE
LoggedIn 탭 바 구성

### DIFF
--- a/Hook/Hook.xcodeproj/project.pbxproj
+++ b/Hook/Hook.xcodeproj/project.pbxproj
@@ -26,6 +26,7 @@
 		6705B5F927815C7400793CB8 /* AccountBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6705B5F527815C7400793CB8 /* AccountBuilder.swift */; };
 		6705B5FA27815C7400793CB8 /* AccountInteractor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6705B5F627815C7400793CB8 /* AccountInteractor.swift */; };
 		6705B61C2781DF3100793CB8 /* LoggedInViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6705B61B2781DF3100793CB8 /* LoggedInViewController.swift */; };
+		6705B61E2782111D00793CB8 /* NavigationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6705B61D2782111D00793CB8 /* NavigationController.swift */; };
 		672B2FD72771A7580075F348 /* KeychainManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 672B2FD62771A7580075F348 /* KeychainManager.swift */; };
 		672B2FDA2771A7A70075F348 /* KeychainError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 672B2FD92771A7A70075F348 /* KeychainError.swift */; };
 		672B2FDD2771A8080075F348 /* KeychainItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 672B2FDC2771A8080075F348 /* KeychainItem.swift */; };
@@ -95,6 +96,7 @@
 		6705B5F527815C7400793CB8 /* AccountBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountBuilder.swift; sourceTree = "<group>"; };
 		6705B5F627815C7400793CB8 /* AccountInteractor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountInteractor.swift; sourceTree = "<group>"; };
 		6705B61B2781DF3100793CB8 /* LoggedInViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoggedInViewController.swift; sourceTree = "<group>"; };
+		6705B61D2782111D00793CB8 /* NavigationController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationController.swift; sourceTree = "<group>"; };
 		670FF4CD27799B4E00F4E64D /* HookTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = HookTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		672B2FD62771A7580075F348 /* KeychainManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeychainManager.swift; sourceTree = "<group>"; };
 		672B2FD92771A7A70075F348 /* KeychainError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeychainError.swift; sourceTree = "<group>"; };
@@ -224,6 +226,7 @@
 				67BDEA36277764CA0031FEC1 /* AutoLayout.swift */,
 				67BDEA3A277786C80031FEC1 /* Convertible.swift */,
 				672B2FD62771A7580075F348 /* KeychainManager.swift */,
+				6705B61D2782111D00793CB8 /* NavigationController.swift */,
 				673A88B1277C05CD00A89DC7 /* Stream.swift */,
 			);
 			path = Utils;
@@ -359,9 +362,9 @@
 				6705B5D827815AE400793CB8 /* Account */,
 				672B2FDE2771B5E70075F348 /* Repositories */,
 				672B2FD52771A73E0075F348 /* Utils */,
+				67EDC92C277175C4003F646F /* Resources */,
 				672B2FDB2771A7D30075F348 /* Models */,
 				672B2FD82771A7990075F348 /* Errors */,
-				67EDC92C277175C4003F646F /* Resources */,
 			);
 			path = Hook;
 			sourceTree = "<group>";
@@ -601,6 +604,7 @@
 				672B2FE22771B6820075F348 /* Credential.swift in Sources */,
 				672B2FE82771D1810075F348 /* AppComponent.swift in Sources */,
 				67BDEA2B2774C7E70031FEC1 /* LoggedOutBuilder.swift in Sources */,
+				6705B61E2782111D00793CB8 /* NavigationController.swift in Sources */,
 				672B2FE62771CFCF0075F348 /* LoginState.swift in Sources */,
 				673A88A8277BF49E00A89DC7 /* String.swift in Sources */,
 				6705B5E027815B3F00793CB8 /* BrowseInteractor.swift in Sources */,
@@ -841,7 +845,7 @@
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations = UIInterfaceOrientationPortrait;
-				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = UIInterfaceOrientationPortrait;
 				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -871,7 +875,7 @@
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations = UIInterfaceOrientationPortrait;
-				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = UIInterfaceOrientationPortrait;
 				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",

--- a/Hook/Hook.xcodeproj/project.pbxproj
+++ b/Hook/Hook.xcodeproj/project.pbxproj
@@ -9,6 +9,22 @@
 /* Begin PBXBuildFile section */
 		5245B402AB6ABC6240F7A980 /* libPods-HookTests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = F811AAEB8B93A88A09DC7BE6 /* libPods-HookTests.a */; };
 		60735617F7FE4C51A00A7BA7 /* libPods-Hook.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 5E4130F480F622AAD23E6D8E /* libPods-Hook.a */; };
+		6705B5DD27815B3F00793CB8 /* BrowseRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6705B5D927815B3F00793CB8 /* BrowseRouter.swift */; };
+		6705B5DE27815B3F00793CB8 /* BrowseViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6705B5DA27815B3F00793CB8 /* BrowseViewController.swift */; };
+		6705B5DF27815B3F00793CB8 /* BrowseBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6705B5DB27815B3F00793CB8 /* BrowseBuilder.swift */; };
+		6705B5E027815B3F00793CB8 /* BrowseInteractor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6705B5DC27815B3F00793CB8 /* BrowseInteractor.swift */; };
+		6705B5E527815BA300793CB8 /* SearchRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6705B5E127815BA300793CB8 /* SearchRouter.swift */; };
+		6705B5E627815BA300793CB8 /* SearchViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6705B5E227815BA300793CB8 /* SearchViewController.swift */; };
+		6705B5E727815BA300793CB8 /* SearchBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6705B5E327815BA300793CB8 /* SearchBuilder.swift */; };
+		6705B5E827815BA300793CB8 /* SearchInteractor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6705B5E427815BA300793CB8 /* SearchInteractor.swift */; };
+		6705B5EF27815C2F00793CB8 /* FavoritesRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6705B5EB27815C2F00793CB8 /* FavoritesRouter.swift */; };
+		6705B5F027815C2F00793CB8 /* FavoritesViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6705B5EC27815C2F00793CB8 /* FavoritesViewController.swift */; };
+		6705B5F127815C2F00793CB8 /* FavoritesBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6705B5ED27815C2F00793CB8 /* FavoritesBuilder.swift */; };
+		6705B5F227815C3000793CB8 /* FavoritesInteractor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6705B5EE27815C2F00793CB8 /* FavoritesInteractor.swift */; };
+		6705B5F727815C7400793CB8 /* AccountRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6705B5F327815C7400793CB8 /* AccountRouter.swift */; };
+		6705B5F827815C7400793CB8 /* AccountViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6705B5F427815C7400793CB8 /* AccountViewController.swift */; };
+		6705B5F927815C7400793CB8 /* AccountBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6705B5F527815C7400793CB8 /* AccountBuilder.swift */; };
+		6705B5FA27815C7400793CB8 /* AccountInteractor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6705B5F627815C7400793CB8 /* AccountInteractor.swift */; };
 		672B2FD72771A7580075F348 /* KeychainManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 672B2FD62771A7580075F348 /* KeychainManager.swift */; };
 		672B2FDA2771A7A70075F348 /* KeychainError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 672B2FD92771A7A70075F348 /* KeychainError.swift */; };
 		672B2FDD2771A8080075F348 /* KeychainItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 672B2FDC2771A8080075F348 /* KeychainItem.swift */; };
@@ -61,6 +77,22 @@
 		04DE1CB86686785A1309BB23 /* Pods-Hook.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Hook.release.xcconfig"; path = "Target Support Files/Pods-Hook/Pods-Hook.release.xcconfig"; sourceTree = "<group>"; };
 		4AB2B7D53C87E2167FFAE354 /* Pods-HookTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-HookTests.debug.xcconfig"; path = "Target Support Files/Pods-HookTests/Pods-HookTests.debug.xcconfig"; sourceTree = "<group>"; };
 		5E4130F480F622AAD23E6D8E /* libPods-Hook.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-Hook.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		6705B5D927815B3F00793CB8 /* BrowseRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowseRouter.swift; sourceTree = "<group>"; };
+		6705B5DA27815B3F00793CB8 /* BrowseViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowseViewController.swift; sourceTree = "<group>"; };
+		6705B5DB27815B3F00793CB8 /* BrowseBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowseBuilder.swift; sourceTree = "<group>"; };
+		6705B5DC27815B3F00793CB8 /* BrowseInteractor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowseInteractor.swift; sourceTree = "<group>"; };
+		6705B5E127815BA300793CB8 /* SearchRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchRouter.swift; sourceTree = "<group>"; };
+		6705B5E227815BA300793CB8 /* SearchViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchViewController.swift; sourceTree = "<group>"; };
+		6705B5E327815BA300793CB8 /* SearchBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchBuilder.swift; sourceTree = "<group>"; };
+		6705B5E427815BA300793CB8 /* SearchInteractor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchInteractor.swift; sourceTree = "<group>"; };
+		6705B5EB27815C2F00793CB8 /* FavoritesRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FavoritesRouter.swift; sourceTree = "<group>"; };
+		6705B5EC27815C2F00793CB8 /* FavoritesViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FavoritesViewController.swift; sourceTree = "<group>"; };
+		6705B5ED27815C2F00793CB8 /* FavoritesBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FavoritesBuilder.swift; sourceTree = "<group>"; };
+		6705B5EE27815C2F00793CB8 /* FavoritesInteractor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FavoritesInteractor.swift; sourceTree = "<group>"; };
+		6705B5F327815C7400793CB8 /* AccountRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountRouter.swift; sourceTree = "<group>"; };
+		6705B5F427815C7400793CB8 /* AccountViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountViewController.swift; sourceTree = "<group>"; };
+		6705B5F527815C7400793CB8 /* AccountBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountBuilder.swift; sourceTree = "<group>"; };
+		6705B5F627815C7400793CB8 /* AccountInteractor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountInteractor.swift; sourceTree = "<group>"; };
 		670FF4CD27799B4E00F4E64D /* HookTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = HookTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		672B2FD62771A7580075F348 /* KeychainManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeychainManager.swift; sourceTree = "<group>"; };
 		672B2FD92771A7A70075F348 /* KeychainError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeychainError.swift; sourceTree = "<group>"; };
@@ -128,6 +160,50 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		6705B5D527815AB700793CB8 /* Browse */ = {
+			isa = PBXGroup;
+			children = (
+				6705B5D927815B3F00793CB8 /* BrowseRouter.swift */,
+				6705B5DC27815B3F00793CB8 /* BrowseInteractor.swift */,
+				6705B5DB27815B3F00793CB8 /* BrowseBuilder.swift */,
+				6705B5DA27815B3F00793CB8 /* BrowseViewController.swift */,
+			);
+			path = Browse;
+			sourceTree = "<group>";
+		};
+		6705B5D627815AC800793CB8 /* Search */ = {
+			isa = PBXGroup;
+			children = (
+				6705B5E127815BA300793CB8 /* SearchRouter.swift */,
+				6705B5E427815BA300793CB8 /* SearchInteractor.swift */,
+				6705B5E327815BA300793CB8 /* SearchBuilder.swift */,
+				6705B5E227815BA300793CB8 /* SearchViewController.swift */,
+			);
+			path = Search;
+			sourceTree = "<group>";
+		};
+		6705B5D727815AD700793CB8 /* Favorites */ = {
+			isa = PBXGroup;
+			children = (
+				6705B5EB27815C2F00793CB8 /* FavoritesRouter.swift */,
+				6705B5EE27815C2F00793CB8 /* FavoritesInteractor.swift */,
+				6705B5ED27815C2F00793CB8 /* FavoritesBuilder.swift */,
+				6705B5EC27815C2F00793CB8 /* FavoritesViewController.swift */,
+			);
+			path = Favorites;
+			sourceTree = "<group>";
+		};
+		6705B5D827815AE400793CB8 /* Account */ = {
+			isa = PBXGroup;
+			children = (
+				6705B5F327815C7400793CB8 /* AccountRouter.swift */,
+				6705B5F627815C7400793CB8 /* AccountInteractor.swift */,
+				6705B5F527815C7400793CB8 /* AccountBuilder.swift */,
+				6705B5F427815C7400793CB8 /* AccountViewController.swift */,
+			);
+			path = Account;
+			sourceTree = "<group>";
+		};
 		670FF4CE27799B4E00F4E64D /* HookTests */ = {
 			isa = PBXGroup;
 			children = (
@@ -274,11 +350,15 @@
 				672B2FEB27749A740075F348 /* Root */,
 				67BDEA242774C7C40031FEC1 /* LoggedOut */,
 				67BDEA2D2774C7F30031FEC1 /* LoggedIn */,
-				672B2FD82771A7990075F348 /* Errors */,
-				672B2FDB2771A7D30075F348 /* Models */,
+				6705B5D527815AB700793CB8 /* Browse */,
+				6705B5D627815AC800793CB8 /* Search */,
+				6705B5D727815AD700793CB8 /* Favorites */,
+				6705B5D827815AE400793CB8 /* Account */,
 				672B2FDE2771B5E70075F348 /* Repositories */,
-				67EDC92C277175C4003F646F /* Resources */,
 				672B2FD52771A73E0075F348 /* Utils */,
+				672B2FDB2771A7D30075F348 /* Models */,
+				672B2FD82771A7990075F348 /* Errors */,
+				67EDC92C277175C4003F646F /* Resources */,
 			);
 			path = Hook;
 			sourceTree = "<group>";
@@ -496,21 +576,31 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				6705B5EF27815C2F00793CB8 /* FavoritesRouter.swift in Sources */,
 				672B2FDD2771A8080075F348 /* KeychainItem.swift in Sources */,
 				67BDEA2A2774C7E70031FEC1 /* LoggedOutViewController.swift in Sources */,
 				67BDEA292774C7E70031FEC1 /* LoggedOutRouter.swift in Sources */,
+				6705B5F727815C7400793CB8 /* AccountRouter.swift in Sources */,
 				672B2FE02771B6420075F348 /* CredentialRepository.swift in Sources */,
+				6705B5E527815BA300793CB8 /* SearchRouter.swift in Sources */,
+				6705B5DD27815B3F00793CB8 /* BrowseRouter.swift in Sources */,
 				67BDEA322774C81F0031FEC1 /* LoggedInBuilder.swift in Sources */,
 				67BDEA312774C81F0031FEC1 /* LoggedInRouter.swift in Sources */,
+				6705B5F227815C3000793CB8 /* FavoritesInteractor.swift in Sources */,
+				6705B5F927815C7400793CB8 /* AccountBuilder.swift in Sources */,
 				672B2FF327749AAA0075F348 /* RootInteractor.swift in Sources */,
 				672B2FF127749AA90075F348 /* RootViewController.swift in Sources */,
 				67EDC91827717476003F646F /* AppDelegate.swift in Sources */,
 				672B2FDA2771A7A70075F348 /* KeychainError.swift in Sources */,
+				6705B5E627815BA300793CB8 /* SearchViewController.swift in Sources */,
+				6705B5E727815BA300793CB8 /* SearchBuilder.swift in Sources */,
 				672B2FE22771B6820075F348 /* Credential.swift in Sources */,
 				672B2FE82771D1810075F348 /* AppComponent.swift in Sources */,
 				67BDEA2B2774C7E70031FEC1 /* LoggedOutBuilder.swift in Sources */,
 				672B2FE62771CFCF0075F348 /* LoginState.swift in Sources */,
 				673A88A8277BF49E00A89DC7 /* String.swift in Sources */,
+				6705B5E027815B3F00793CB8 /* BrowseInteractor.swift in Sources */,
+				6705B5DE27815B3F00793CB8 /* BrowseViewController.swift in Sources */,
 				672B2FF227749AAA0075F348 /* RootBuilder.swift in Sources */,
 				67BDEA39277768B10031FEC1 /* Size.swift in Sources */,
 				673A88AD277BF64000A89DC7 /* LocalizedString.swift in Sources */,
@@ -518,11 +608,17 @@
 				67BDEA3B277786C80031FEC1 /* Convertible.swift in Sources */,
 				672B2FF027749AA90075F348 /* RootRouter.swift in Sources */,
 				67BDEA352774CD210031FEC1 /* ViewControllable.swift in Sources */,
+				6705B5F127815C2F00793CB8 /* FavoritesBuilder.swift in Sources */,
 				672B2FD72771A7580075F348 /* KeychainManager.swift in Sources */,
+				6705B5DF27815B3F00793CB8 /* BrowseBuilder.swift in Sources */,
+				6705B5F027815C2F00793CB8 /* FavoritesViewController.swift in Sources */,
 				67BDEA332774C81F0031FEC1 /* LoggedInInteractor.swift in Sources */,
 				673A889F277B7E7600A89DC7 /* NotificationName.swift in Sources */,
+				6705B5FA27815C7400793CB8 /* AccountInteractor.swift in Sources */,
+				6705B5F827815C7400793CB8 /* AccountViewController.swift in Sources */,
 				67BDEA2C2774C7E70031FEC1 /* LoggedOutInteractor.swift in Sources */,
 				673A88B2277C05CD00A89DC7 /* Stream.swift in Sources */,
+				6705B5E827815BA300793CB8 /* SearchInteractor.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Hook/Hook.xcodeproj/project.pbxproj
+++ b/Hook/Hook.xcodeproj/project.pbxproj
@@ -25,6 +25,7 @@
 		6705B5F827815C7400793CB8 /* AccountViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6705B5F427815C7400793CB8 /* AccountViewController.swift */; };
 		6705B5F927815C7400793CB8 /* AccountBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6705B5F527815C7400793CB8 /* AccountBuilder.swift */; };
 		6705B5FA27815C7400793CB8 /* AccountInteractor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6705B5F627815C7400793CB8 /* AccountInteractor.swift */; };
+		6705B61C2781DF3100793CB8 /* LoggedInViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6705B61B2781DF3100793CB8 /* LoggedInViewController.swift */; };
 		672B2FD72771A7580075F348 /* KeychainManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 672B2FD62771A7580075F348 /* KeychainManager.swift */; };
 		672B2FDA2771A7A70075F348 /* KeychainError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 672B2FD92771A7A70075F348 /* KeychainError.swift */; };
 		672B2FDD2771A8080075F348 /* KeychainItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 672B2FDC2771A8080075F348 /* KeychainItem.swift */; };
@@ -93,6 +94,7 @@
 		6705B5F427815C7400793CB8 /* AccountViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountViewController.swift; sourceTree = "<group>"; };
 		6705B5F527815C7400793CB8 /* AccountBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountBuilder.swift; sourceTree = "<group>"; };
 		6705B5F627815C7400793CB8 /* AccountInteractor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountInteractor.swift; sourceTree = "<group>"; };
+		6705B61B2781DF3100793CB8 /* LoggedInViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoggedInViewController.swift; sourceTree = "<group>"; };
 		670FF4CD27799B4E00F4E64D /* HookTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = HookTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		672B2FD62771A7580075F348 /* KeychainManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeychainManager.swift; sourceTree = "<group>"; };
 		672B2FD92771A7A70075F348 /* KeychainError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeychainError.swift; sourceTree = "<group>"; };
@@ -318,6 +320,7 @@
 				67BDEA2E2774C81F0031FEC1 /* LoggedInRouter.swift */,
 				67BDEA302774C81F0031FEC1 /* LoggedInInteractor.swift */,
 				67BDEA2F2774C81F0031FEC1 /* LoggedInBuilder.swift */,
+				6705B61B2781DF3100793CB8 /* LoggedInViewController.swift */,
 			);
 			path = LoggedIn;
 			sourceTree = "<group>";
@@ -587,6 +590,7 @@
 				67BDEA322774C81F0031FEC1 /* LoggedInBuilder.swift in Sources */,
 				67BDEA312774C81F0031FEC1 /* LoggedInRouter.swift in Sources */,
 				6705B5F227815C3000793CB8 /* FavoritesInteractor.swift in Sources */,
+				6705B61C2781DF3100793CB8 /* LoggedInViewController.swift in Sources */,
 				6705B5F927815C7400793CB8 /* AccountBuilder.swift in Sources */,
 				672B2FF327749AAA0075F348 /* RootInteractor.swift in Sources */,
 				672B2FF127749AA90075F348 /* RootViewController.swift in Sources */,

--- a/Hook/Hook/Account/AccountBuilder.swift
+++ b/Hook/Hook/Account/AccountBuilder.swift
@@ -1,0 +1,32 @@
+//
+//  AccountBuilder.swift
+//  Hook
+//
+//  Created by Yeojin Yoon on 2022/01/02.
+//
+
+import RIBs
+
+protocol AccountDependency: Dependency {}
+
+final class AccountComponent: Component<AccountDependency> {}
+
+// MARK: - Builder
+
+protocol AccountBuildable: Buildable {
+    func build(withListener listener: AccountListener) -> AccountRouting
+}
+
+final class AccountBuilder: Builder<AccountDependency>, AccountBuildable {
+
+    override init(dependency: AccountDependency) {
+        super.init(dependency: dependency)
+    }
+
+    func build(withListener listener: AccountListener) -> AccountRouting {
+        let viewController = AccountViewController()
+        let interactor = AccountInteractor(presenter: viewController)
+        interactor.listener = listener
+        return AccountRouter(interactor: interactor, viewController: viewController)
+    }
+}

--- a/Hook/Hook/Account/AccountInteractor.swift
+++ b/Hook/Hook/Account/AccountInteractor.swift
@@ -1,0 +1,35 @@
+//
+//  AccountInteractor.swift
+//  Hook
+//
+//  Created by Yeojin Yoon on 2022/01/02.
+//
+
+import RIBs
+
+protocol AccountRouting: ViewableRouting {}
+
+protocol AccountPresentable: Presentable {
+    var listener: AccountPresentableListener? { get set }
+}
+
+protocol AccountListener: AnyObject {}
+
+final class AccountInteractor: PresentableInteractor<AccountPresentable>, AccountInteractable, AccountPresentableListener {
+
+    weak var router: AccountRouting?
+    weak var listener: AccountListener?
+    
+    override init(presenter: AccountPresentable) {
+        super.init(presenter: presenter)
+        presenter.listener = self
+    }
+
+    override func didBecomeActive() {
+        super.didBecomeActive()
+    }
+
+    override func willResignActive() {
+        super.willResignActive()
+    }
+}

--- a/Hook/Hook/Account/AccountRouter.swift
+++ b/Hook/Hook/Account/AccountRouter.swift
@@ -1,0 +1,23 @@
+//
+//  AccountRouter.swift
+//  Hook
+//
+//  Created by Yeojin Yoon on 2022/01/02.
+//
+
+import RIBs
+
+protocol AccountInteractable: Interactable {
+    var router: AccountRouting? { get set }
+    var listener: AccountListener? { get set }
+}
+
+protocol AccountViewControllable: ViewControllable {}
+
+final class AccountRouter: ViewableRouter<AccountInteractable, AccountViewControllable>, AccountRouting {
+    
+    override init(interactor: AccountInteractable, viewController: AccountViewControllable) {
+        super.init(interactor: interactor, viewController: viewController)
+        interactor.router = self
+    }
+}

--- a/Hook/Hook/Account/AccountViewController.swift
+++ b/Hook/Hook/Account/AccountViewController.swift
@@ -1,0 +1,16 @@
+//
+//  AccountViewController.swift
+//  Hook
+//
+//  Created by Yeojin Yoon on 2022/01/02.
+//
+
+import RIBs
+import UIKit
+
+protocol AccountPresentableListener: AnyObject {}
+
+final class AccountViewController: UIViewController, AccountPresentable, AccountViewControllable {
+
+    weak var listener: AccountPresentableListener?
+}

--- a/Hook/Hook/Account/AccountViewController.swift
+++ b/Hook/Hook/Account/AccountViewController.swift
@@ -26,6 +26,8 @@ final class AccountViewController: UIViewController, AccountPresentable, Account
     
     private func configureViews() {
         title = LocalizedString.ViewTitle.account
-        tabBarItem = UITabBarItem(title: nil, image: UIImage(systemName: "person.crop.circle"), selectedImage: UIImage(systemName: "person.crop.circle.fill"))
+        tabBarItem = UITabBarItem(title: nil,
+                                  image: UIImage(systemName: "person.crop.circle"),
+                                  selectedImage: UIImage(systemName: "person.crop.circle.fill"))
     }
 }

--- a/Hook/Hook/Account/AccountViewController.swift
+++ b/Hook/Hook/Account/AccountViewController.swift
@@ -13,4 +13,19 @@ protocol AccountPresentableListener: AnyObject {}
 final class AccountViewController: UIViewController, AccountPresentable, AccountViewControllable {
 
     weak var listener: AccountPresentableListener?
+    
+    init() {
+        super.init(nibName: nil, bundle: nil)
+        configureViews()
+    }
+    
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+        configureViews()
+    }
+    
+    private func configureViews() {
+        title = LocalizedString.ViewTitle.account
+        tabBarItem = UITabBarItem(title: nil, image: UIImage(systemName: "person.crop.circle"), selectedImage: UIImage(systemName: "person.crop.circle.fill"))
+    }
 }

--- a/Hook/Hook/Browse/BrowseBuilder.swift
+++ b/Hook/Hook/Browse/BrowseBuilder.swift
@@ -1,0 +1,32 @@
+//
+//  BrowseBuilder.swift
+//  Hook
+//
+//  Created by Yeojin Yoon on 2022/01/02.
+//
+
+import RIBs
+
+protocol BrowseDependency: Dependency {}
+
+final class BrowseComponent: Component<BrowseDependency> {}
+
+// MARK: - Builder
+
+protocol BrowseBuildable: Buildable {
+    func build(withListener listener: BrowseListener) -> BrowseRouting
+}
+
+final class BrowseBuilder: Builder<BrowseDependency>, BrowseBuildable {
+
+    override init(dependency: BrowseDependency) {
+        super.init(dependency: dependency)
+    }
+
+    func build(withListener listener: BrowseListener) -> BrowseRouting {
+        let viewController = BrowseViewController()
+        let interactor = BrowseInteractor(presenter: viewController)
+        interactor.listener = listener
+        return BrowseRouter(interactor: interactor, viewController: viewController)
+    }
+}

--- a/Hook/Hook/Browse/BrowseInteractor.swift
+++ b/Hook/Hook/Browse/BrowseInteractor.swift
@@ -1,0 +1,35 @@
+//
+//  BrowseInteractor.swift
+//  Hook
+//
+//  Created by Yeojin Yoon on 2022/01/02.
+//
+
+import RIBs
+
+protocol BrowseRouting: ViewableRouting {}
+
+protocol BrowsePresentable: Presentable {
+    var listener: BrowsePresentableListener? { get set }
+}
+
+protocol BrowseListener: AnyObject {}
+
+final class BrowseInteractor: PresentableInteractor<BrowsePresentable>, BrowseInteractable, BrowsePresentableListener {
+
+    weak var router: BrowseRouting?
+    weak var listener: BrowseListener?
+    
+    override init(presenter: BrowsePresentable) {
+        super.init(presenter: presenter)
+        presenter.listener = self
+    }
+
+    override func didBecomeActive() {
+        super.didBecomeActive()
+    }
+
+    override func willResignActive() {
+        super.willResignActive()
+    }
+}

--- a/Hook/Hook/Browse/BrowseRouter.swift
+++ b/Hook/Hook/Browse/BrowseRouter.swift
@@ -1,0 +1,23 @@
+//
+//  BrowseRouter.swift
+//  Hook
+//
+//  Created by Yeojin Yoon on 2022/01/02.
+//
+
+import RIBs
+
+protocol BrowseInteractable: Interactable {
+    var router: BrowseRouting? { get set }
+    var listener: BrowseListener? { get set }
+}
+
+protocol BrowseViewControllable: ViewControllable {}
+
+final class BrowseRouter: ViewableRouter<BrowseInteractable, BrowseViewControllable>, BrowseRouting {
+    
+    override init(interactor: BrowseInteractable, viewController: BrowseViewControllable) {
+        super.init(interactor: interactor, viewController: viewController)
+        interactor.router = self
+    }
+}

--- a/Hook/Hook/Browse/BrowseViewController.swift
+++ b/Hook/Hook/Browse/BrowseViewController.swift
@@ -13,4 +13,19 @@ protocol BrowsePresentableListener: AnyObject {}
 final class BrowseViewController: UIViewController, BrowsePresentable, BrowseViewControllable {
 
     weak var listener: BrowsePresentableListener?
+    
+    init() {
+        super.init(nibName: nil, bundle: nil)
+        configureViews()
+    }
+    
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+        configureViews()
+    }
+    
+    private func configureViews() {
+        title = LocalizedString.ViewTitle.browse
+        tabBarItem = UITabBarItem(title: nil, image: UIImage(systemName: "rectangle.grid.1x2"), selectedImage: UIImage(systemName: "rectangle.grid.1x2.fill"))
+    }
 }

--- a/Hook/Hook/Browse/BrowseViewController.swift
+++ b/Hook/Hook/Browse/BrowseViewController.swift
@@ -26,6 +26,8 @@ final class BrowseViewController: UIViewController, BrowsePresentable, BrowseVie
     
     private func configureViews() {
         title = LocalizedString.ViewTitle.browse
-        tabBarItem = UITabBarItem(title: nil, image: UIImage(systemName: "rectangle.grid.1x2"), selectedImage: UIImage(systemName: "rectangle.grid.1x2.fill"))
+        tabBarItem = UITabBarItem(title: nil,
+                                  image: UIImage(systemName: "rectangle.grid.1x2"),
+                                  selectedImage: UIImage(systemName: "rectangle.grid.1x2.fill"))
     }
 }

--- a/Hook/Hook/Browse/BrowseViewController.swift
+++ b/Hook/Hook/Browse/BrowseViewController.swift
@@ -1,0 +1,16 @@
+//
+//  BrowseViewController.swift
+//  Hook
+//
+//  Created by Yeojin Yoon on 2022/01/02.
+//
+
+import RIBs
+import UIKit
+
+protocol BrowsePresentableListener: AnyObject {}
+
+final class BrowseViewController: UIViewController, BrowsePresentable, BrowseViewControllable {
+
+    weak var listener: BrowsePresentableListener?
+}

--- a/Hook/Hook/Favorites/FavoritesBuilder.swift
+++ b/Hook/Hook/Favorites/FavoritesBuilder.swift
@@ -1,0 +1,32 @@
+//
+//  FavoritesBuilder.swift
+//  Hook
+//
+//  Created by Yeojin Yoon on 2022/01/02.
+//
+
+import RIBs
+
+protocol FavoritesDependency: Dependency {}
+
+final class FavoritesComponent: Component<FavoritesDependency> {}
+
+// MARK: - Builder
+
+protocol FavoritesBuildable: Buildable {
+    func build(withListener listener: FavoritesListener) -> FavoritesRouting
+}
+
+final class FavoritesBuilder: Builder<FavoritesDependency>, FavoritesBuildable {
+
+    override init(dependency: FavoritesDependency) {
+        super.init(dependency: dependency)
+    }
+
+    func build(withListener listener: FavoritesListener) -> FavoritesRouting {
+        let viewController = FavoritesViewController()
+        let interactor = FavoritesInteractor(presenter: viewController)
+        interactor.listener = listener
+        return FavoritesRouter(interactor: interactor, viewController: viewController)
+    }
+}

--- a/Hook/Hook/Favorites/FavoritesInteractor.swift
+++ b/Hook/Hook/Favorites/FavoritesInteractor.swift
@@ -1,0 +1,35 @@
+//
+//  FavoritesInteractor.swift
+//  Hook
+//
+//  Created by Yeojin Yoon on 2022/01/02.
+//
+
+import RIBs
+
+protocol FavoritesRouting: ViewableRouting {}
+
+protocol FavoritesPresentable: Presentable {
+    var listener: FavoritesPresentableListener? { get set }
+}
+
+protocol FavoritesListener: AnyObject {}
+
+final class FavoritesInteractor: PresentableInteractor<FavoritesPresentable>, FavoritesInteractable, FavoritesPresentableListener {
+
+    weak var router: FavoritesRouting?
+    weak var listener: FavoritesListener?
+    
+    override init(presenter: FavoritesPresentable) {
+        super.init(presenter: presenter)
+        presenter.listener = self
+    }
+
+    override func didBecomeActive() {
+        super.didBecomeActive()
+    }
+
+    override func willResignActive() {
+        super.willResignActive()
+    }
+}

--- a/Hook/Hook/Favorites/FavoritesRouter.swift
+++ b/Hook/Hook/Favorites/FavoritesRouter.swift
@@ -1,0 +1,23 @@
+//
+//  FavoritesRouter.swift
+//  Hook
+//
+//  Created by Yeojin Yoon on 2022/01/02.
+//
+
+import RIBs
+
+protocol FavoritesInteractable: Interactable {
+    var router: FavoritesRouting? { get set }
+    var listener: FavoritesListener? { get set }
+}
+
+protocol FavoritesViewControllable: ViewControllable {}
+
+final class FavoritesRouter: ViewableRouter<FavoritesInteractable, FavoritesViewControllable>, FavoritesRouting {
+    
+    override init(interactor: FavoritesInteractable, viewController: FavoritesViewControllable) {
+        super.init(interactor: interactor, viewController: viewController)
+        interactor.router = self
+    }
+}

--- a/Hook/Hook/Favorites/FavoritesViewController.swift
+++ b/Hook/Hook/Favorites/FavoritesViewController.swift
@@ -13,4 +13,19 @@ protocol FavoritesPresentableListener: AnyObject {}
 final class FavoritesViewController: UIViewController, FavoritesPresentable, FavoritesViewControllable {
 
     weak var listener: FavoritesPresentableListener?
+    
+    init() {
+        super.init(nibName: nil, bundle: nil)
+        configureViews()
+    }
+    
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+        configureViews()
+    }
+    
+    private func configureViews() {
+        title = LocalizedString.ViewTitle.favorites
+        tabBarItem = UITabBarItem(title: nil, image: UIImage(systemName: "bookmark"), selectedImage: UIImage(systemName: "bookmark.fill"))
+    }
 }

--- a/Hook/Hook/Favorites/FavoritesViewController.swift
+++ b/Hook/Hook/Favorites/FavoritesViewController.swift
@@ -26,6 +26,8 @@ final class FavoritesViewController: UIViewController, FavoritesPresentable, Fav
     
     private func configureViews() {
         title = LocalizedString.ViewTitle.favorites
-        tabBarItem = UITabBarItem(title: nil, image: UIImage(systemName: "bookmark"), selectedImage: UIImage(systemName: "bookmark.fill"))
+        tabBarItem = UITabBarItem(title: nil,
+                                  image: UIImage(systemName: "bookmark"),
+                                  selectedImage: UIImage(systemName: "bookmark.fill"))
     }
 }

--- a/Hook/Hook/Favorites/FavoritesViewController.swift
+++ b/Hook/Hook/Favorites/FavoritesViewController.swift
@@ -1,0 +1,16 @@
+//
+//  FavoritesViewController.swift
+//  Hook
+//
+//  Created by Yeojin Yoon on 2022/01/02.
+//
+
+import RIBs
+import UIKit
+
+protocol FavoritesPresentableListener: AnyObject {}
+
+final class FavoritesViewController: UIViewController, FavoritesPresentable, FavoritesViewControllable {
+
+    weak var listener: FavoritesPresentableListener?
+}

--- a/Hook/Hook/LoggedIn/LoggedInBuilder.swift
+++ b/Hook/Hook/LoggedIn/LoggedInBuilder.swift
@@ -9,7 +9,7 @@ import RIBs
 
 protocol LoggedInDependency: Dependency {}
 
-final class LoggedInComponent: Component<LoggedInDependency> {
+final class LoggedInComponent: Component<LoggedInDependency>, BrowseDependency, SearchDependency, FavoritesDependency, AccountDependency {
     
     let credential: Credential
     
@@ -33,8 +33,18 @@ final class LoggedInBuilder: Builder<LoggedInDependency>, LoggedInBuildable {
 
     func build(withListener listener: LoggedInListener, credential: Credential) -> LoggedInRouting {
         let viewController = LoggedInViewController()
+        let component = LoggedInComponent(dependency: dependency, credential: credential)
         let interactor = LoggedInInteractor(presenter: viewController)
         interactor.listener = listener
-        return LoggedInRouter(interactor: interactor, viewController: viewController)
+        let browse = BrowseBuilder(dependency: component)
+        let search = SearchBuilder(dependency: component)
+        let favorites = FavoritesBuilder(dependency: component)
+        let account = AccountBuilder(dependency: component)
+        return LoggedInRouter(interactor: interactor,
+                              viewController: viewController,
+                              browse: browse,
+                              search: search,
+                              favorites: favorites,
+                              account: account)
     }
 }

--- a/Hook/Hook/LoggedIn/LoggedInBuilder.swift
+++ b/Hook/Hook/LoggedIn/LoggedInBuilder.swift
@@ -7,13 +7,9 @@
 
 import RIBs
 
-protocol LoggedInDependency: Dependency {
-    var loggedInViewController: LoggedInViewControllable { get }
-}
+protocol LoggedInDependency: Dependency {}
 
 final class LoggedInComponent: Component<LoggedInDependency> {
-    
-    fileprivate var loggedInViewController: LoggedInViewControllable { dependency.loggedInViewController }
     
     let credential: Credential
     
@@ -36,9 +32,9 @@ final class LoggedInBuilder: Builder<LoggedInDependency>, LoggedInBuildable {
     }
 
     func build(withListener listener: LoggedInListener, credential: Credential) -> LoggedInRouting {
-        let component = LoggedInComponent(dependency: dependency, credential: credential)
-        let interactor = LoggedInInteractor()
+        let viewController = LoggedInViewController()
+        let interactor = LoggedInInteractor(presenter: viewController)
         interactor.listener = listener
-        return LoggedInRouter(interactor: interactor, viewController: component.loggedInViewController)
+        return LoggedInRouter(interactor: interactor, viewController: viewController)
     }
 }

--- a/Hook/Hook/LoggedIn/LoggedInInteractor.swift
+++ b/Hook/Hook/LoggedIn/LoggedInInteractor.swift
@@ -7,18 +7,23 @@
 
 import RIBs
 
-protocol LoggedInRouting: Routing {
-    func cleanupViews()
+protocol LoggedInRouting: ViewableRouting {}
+
+protocol LoggedInPresentable: Presentable {
+    var listener: LoggedInPresentableListener? { get set }
 }
 
 protocol LoggedInListener: AnyObject {}
 
-final class LoggedInInteractor: Interactor, LoggedInInteractable {
+final class LoggedInInteractor: PresentableInteractor<LoggedInPresentable>, LoggedInInteractable, LoggedInPresentableListener {
 
     weak var router: LoggedInRouting?
     weak var listener: LoggedInListener?
     
-    override init() {}
+    override init(presenter: LoggedInPresentable) {
+        super.init(presenter: presenter)
+        presenter.listener = self
+    }
 
     override func didBecomeActive() {
         super.didBecomeActive()
@@ -26,6 +31,5 @@ final class LoggedInInteractor: Interactor, LoggedInInteractable {
 
     override func willResignActive() {
         super.willResignActive()
-        router?.cleanupViews()
     }
 }

--- a/Hook/Hook/LoggedIn/LoggedInInteractor.swift
+++ b/Hook/Hook/LoggedIn/LoggedInInteractor.swift
@@ -7,7 +7,9 @@
 
 import RIBs
 
-protocol LoggedInRouting: ViewableRouting {}
+protocol LoggedInRouting: ViewableRouting {
+    func attachTabs()
+}
 
 protocol LoggedInPresentable: Presentable {
     var listener: LoggedInPresentableListener? { get set }
@@ -27,6 +29,7 @@ final class LoggedInInteractor: PresentableInteractor<LoggedInPresentable>, Logg
 
     override func didBecomeActive() {
         super.didBecomeActive()
+        router?.attachTabs()
     }
 
     override func willResignActive() {

--- a/Hook/Hook/LoggedIn/LoggedInRouter.swift
+++ b/Hook/Hook/LoggedIn/LoggedInRouter.swift
@@ -14,15 +14,10 @@ protocol LoggedInInteractable: Interactable {
 
 protocol LoggedInViewControllable: ViewControllable {}
 
-final class LoggedInRouter: Router<LoggedInInteractable>, LoggedInRouting {
+final class LoggedInRouter: ViewableRouter<LoggedInInteractable, LoggedInViewControllable>, LoggedInRouting {
     
-    private let viewController: LoggedInViewControllable
-    
-    init(interactor: LoggedInInteractable, viewController: LoggedInViewControllable) {
-        self.viewController = viewController
-        super.init(interactor: interactor)
+    override init(interactor: LoggedInInteractable, viewController: LoggedInViewControllable) {
+        super.init(interactor: interactor, viewController: viewController)
         interactor.router = self
     }
-
-    func cleanupViews() {}
 }

--- a/Hook/Hook/LoggedIn/LoggedInRouter.swift
+++ b/Hook/Hook/LoggedIn/LoggedInRouter.swift
@@ -7,17 +7,52 @@
 
 import RIBs
 
-protocol LoggedInInteractable: Interactable {
+protocol LoggedInInteractable: Interactable, BrowseListener, SearchListener, FavoritesListener, AccountListener {
     var router: LoggedInRouting? { get set }
     var listener: LoggedInListener? { get set }
 }
 
-protocol LoggedInViewControllable: ViewControllable {}
+protocol LoggedInViewControllable: ViewControllable {
+    func setViewControllers(_ viewControllers: [ViewControllable])
+}
 
 final class LoggedInRouter: ViewableRouter<LoggedInInteractable, LoggedInViewControllable>, LoggedInRouting {
     
-    override init(interactor: LoggedInInteractable, viewController: LoggedInViewControllable) {
+    private let browse: BrowseBuildable
+    private let search: SearchBuildable
+    private let favorites: FavoritesBuildable
+    private let account: AccountBuildable
+    
+    init(interactor: LoggedInInteractable,
+         viewController: LoggedInViewControllable,
+         browse: BrowseBuildable,
+         search: SearchBuildable,
+         favorites: FavoritesBuildable,
+         account: AccountBuildable) {
+        self.browse = browse
+        self.search = search
+        self.favorites = favorites
+        self.account = account
         super.init(interactor: interactor, viewController: viewController)
         interactor.router = self
+    }
+    
+    func attachTabs() {
+        let browseRouter = browse.build(withListener: interactor)
+        let searchRouter = search.build(withListener: interactor)
+        let favoritesRouter = favorites.build(withListener: interactor)
+        let accountRouter = account.build(withListener: interactor)
+        
+        attachChild(browseRouter)
+        attachChild(searchRouter)
+        attachChild(favoritesRouter)
+        attachChild(accountRouter)
+        
+        let viewControllers = [NavigationController(root: browseRouter.viewControllable),
+                               NavigationController(root: searchRouter.viewControllable),
+                               NavigationController(root: favoritesRouter.viewControllable),
+                               NavigationController(root: accountRouter.viewControllable)]
+        
+        viewController.setViewControllers(viewControllers)
     }
 }

--- a/Hook/Hook/LoggedIn/LoggedInViewController.swift
+++ b/Hook/Hook/LoggedIn/LoggedInViewController.swift
@@ -10,11 +10,21 @@ import UIKit
 
 protocol LoggedInPresentableListener: AnyObject {}
 
-final class LoggedInViewController: UIViewController, LoggedInPresentable, LoggedInViewControllable {
+final class LoggedInViewController: UITabBarController, LoggedInPresentable, LoggedInViewControllable {
     
     weak var listener: LoggedInPresentableListener?
     
     override func viewDidLoad() {
         super.viewDidLoad()
+        configureViews()
+    }
+    
+    func setViewControllers(_ viewControllers: [ViewControllable]) {
+        super.setViewControllers(viewControllers.map(\.uiviewController), animated: false)
+    }
+    
+    private func configureViews() {
+        view.backgroundColor = .white
+        tabBar.tintColor = .black
     }
 }

--- a/Hook/Hook/LoggedIn/LoggedInViewController.swift
+++ b/Hook/Hook/LoggedIn/LoggedInViewController.swift
@@ -1,0 +1,20 @@
+//
+//  LoggedInViewController.swift
+//  Hook
+//
+//  Created by Yeojin Yoon on 2022/01/02.
+//
+
+import RIBs
+import UIKit
+
+protocol LoggedInPresentableListener: AnyObject {}
+
+final class LoggedInViewController: UIViewController, LoggedInPresentable, LoggedInViewControllable {
+    
+    weak var listener: LoggedInPresentableListener?
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+    }
+}

--- a/Hook/Hook/Resources/en.lproj/Localizable.strings
+++ b/Hook/Hook/Resources/en.lproj/Localizable.strings
@@ -6,3 +6,9 @@
 
 /* Alert action title */
 "OK" = "OK";
+
+/* View title */
+"Browse" = "Browse";
+"Search" = "Search";
+"Favorites" = "Favorites";
+"Account" = "Account";

--- a/Hook/Hook/Resources/ko.lproj/Localizable.strings
+++ b/Hook/Hook/Resources/ko.lproj/Localizable.strings
@@ -6,3 +6,9 @@
 
 /* Alert action title */
 "OK" = "확인";
+
+/* View title */
+"Browse" = "둘러보기";
+"Search" = "검색";
+"Favorites" = "즐겨찾기";
+"Account" = "계정";

--- a/Hook/Hook/Root/RootBuilder.swift
+++ b/Hook/Hook/Root/RootBuilder.swift
@@ -13,11 +13,9 @@ protocol RootDependency: Dependency {
 
 final class RootComponent: Component<RootDependency>, RootInteractorDependency, LoggedOutDependency, LoggedInDependency {
     
-    var loggedInViewController: LoggedInViewControllable
     var loginStateStream: ReadOnlyStream<LoginState> { dependency.loginStateStream }
     
-    init(dependency: RootDependency, loggedInViewController: LoggedInViewControllable) {
-        self.loggedInViewController = loggedInViewController
+    override init(dependency: RootDependency) {
         super.init(dependency: dependency)
     }
 }
@@ -36,7 +34,7 @@ final class RootBuilder: Builder<RootDependency>, RootBuildable {
 
     func build(withListener listener: RootListener) -> LaunchRouting {
         let viewController = RootViewController()
-        let component = RootComponent(dependency: dependency, loggedInViewController: viewController)
+        let component = RootComponent(dependency: dependency)
         let interactor = RootInteractor(presenter: viewController, dependency: component)
         interactor.listener = listener
         let loggedOut = LoggedOutBuilder(dependency: component)

--- a/Hook/Hook/Root/RootRouter.swift
+++ b/Hook/Hook/Root/RootRouter.swift
@@ -19,8 +19,8 @@ final class RootRouter: LaunchRouter<RootInteractable, RootViewControllable>, Ro
     private let loggedOut: LoggedOutBuildable
     private let loggedIn: LoggedInBuildable
     
-    private var loggedOutRouting: Routing?
-    private var loggedInRouting: Routing?
+    private var loggedOutRouter: Routing?
+    private var loggedInRouter: Routing?
     
     init(interactor: RootInteractable,
          viewController: RootViewControllable,
@@ -43,32 +43,32 @@ final class RootRouter: LaunchRouter<RootInteractable, RootViewControllable>, Ro
     }
     
     private func attachLoggedOut() {
-        guard loggedOutRouting == nil else { return }
+        guard loggedOutRouter == nil else { return }
         let router = loggedOut.build(withListener: interactor)
-        loggedOutRouting = router
+        loggedOutRouter = router
         attachChild(router)
         viewController.present(router.viewControllable)
     }
     
     private func detachLoggedOut() {
-        guard let router = loggedOutRouting else { return }
+        guard let router = loggedOutRouter else { return }
         viewController.dismiss()
         detachChild(router)
-        loggedOutRouting = nil
+        loggedOutRouter = nil
     }
     
     private func attachLoggedIn(withCredential credential: Credential) {
-        guard loggedInRouting == nil else { return }
+        guard loggedInRouter == nil else { return }
         let router = loggedIn.build(withListener: interactor, credential: credential)
-        loggedInRouting = router
+        loggedInRouter = router
         attachChild(router)
         viewController.present(router.viewControllable)
     }
     
     private func detachLoggedIn() {
-        guard let router = loggedInRouting else { return }
+        guard let router = loggedInRouter else { return }
         viewController.dismiss()
         detachChild(router)
-        loggedInRouting = nil
+        loggedInRouter = nil
     }
 }

--- a/Hook/Hook/Root/RootRouter.swift
+++ b/Hook/Hook/Root/RootRouter.swift
@@ -62,10 +62,12 @@ final class RootRouter: LaunchRouter<RootInteractable, RootViewControllable>, Ro
         let router = loggedIn.build(withListener: interactor, credential: credential)
         loggedInRouting = router
         attachChild(router)
+        viewController.present(router.viewControllable)
     }
     
     private func detachLoggedIn() {
         guard let router = loggedInRouting else { return }
+        viewController.dismiss()
         detachChild(router)
         loggedInRouting = nil
     }

--- a/Hook/Hook/Root/RootViewController.swift
+++ b/Hook/Hook/Root/RootViewController.swift
@@ -10,9 +10,13 @@ import UIKit
 
 protocol RootPresentableListener: AnyObject {}
 
-final class RootViewController: UIViewController, RootPresentable, RootViewControllable, LoggedInViewControllable {
+final class RootViewController: UIViewController, RootPresentable, RootViewControllable {
 
     weak var listener: RootPresentableListener?
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+    }
     
     func displayAlert(withTitle title: String, message: String) {
         presentAlert(withTitle: title, message: message)

--- a/Hook/Hook/Search/SearchBuilder.swift
+++ b/Hook/Hook/Search/SearchBuilder.swift
@@ -1,0 +1,32 @@
+//
+//  SearchBuilder.swift
+//  Hook
+//
+//  Created by Yeojin Yoon on 2022/01/02.
+//
+
+import RIBs
+
+protocol SearchDependency: Dependency {}
+
+final class SearchComponent: Component<SearchDependency> {}
+
+// MARK: - Builder
+
+protocol SearchBuildable: Buildable {
+    func build(withListener listener: SearchListener) -> SearchRouting
+}
+
+final class SearchBuilder: Builder<SearchDependency>, SearchBuildable {
+
+    override init(dependency: SearchDependency) {
+        super.init(dependency: dependency)
+    }
+
+    func build(withListener listener: SearchListener) -> SearchRouting {
+        let viewController = SearchViewController()
+        let interactor = SearchInteractor(presenter: viewController)
+        interactor.listener = listener
+        return SearchRouter(interactor: interactor, viewController: viewController)
+    }
+}

--- a/Hook/Hook/Search/SearchInteractor.swift
+++ b/Hook/Hook/Search/SearchInteractor.swift
@@ -1,0 +1,35 @@
+//
+//  SearchInteractor.swift
+//  Hook
+//
+//  Created by Yeojin Yoon on 2022/01/02.
+//
+
+import RIBs
+
+protocol SearchRouting: ViewableRouting {}
+
+protocol SearchPresentable: Presentable {
+    var listener: SearchPresentableListener? { get set }
+}
+
+protocol SearchListener: AnyObject {}
+
+final class SearchInteractor: PresentableInteractor<SearchPresentable>, SearchInteractable, SearchPresentableListener {
+
+    weak var router: SearchRouting?
+    weak var listener: SearchListener?
+    
+    override init(presenter: SearchPresentable) {
+        super.init(presenter: presenter)
+        presenter.listener = self
+    }
+
+    override func didBecomeActive() {
+        super.didBecomeActive()
+    }
+
+    override func willResignActive() {
+        super.willResignActive()
+    }
+}

--- a/Hook/Hook/Search/SearchRouter.swift
+++ b/Hook/Hook/Search/SearchRouter.swift
@@ -1,0 +1,23 @@
+//
+//  SearchRouter.swift
+//  Hook
+//
+//  Created by Yeojin Yoon on 2022/01/02.
+//
+
+import RIBs
+
+protocol SearchInteractable: Interactable {
+    var router: SearchRouting? { get set }
+    var listener: SearchListener? { get set }
+}
+
+protocol SearchViewControllable: ViewControllable {}
+
+final class SearchRouter: ViewableRouter<SearchInteractable, SearchViewControllable>, SearchRouting {
+    
+    override init(interactor: SearchInteractable, viewController: SearchViewControllable) {
+        super.init(interactor: interactor, viewController: viewController)
+        interactor.router = self
+    }
+}

--- a/Hook/Hook/Search/SearchViewController.swift
+++ b/Hook/Hook/Search/SearchViewController.swift
@@ -13,4 +13,19 @@ protocol SearchPresentableListener: AnyObject {}
 final class SearchViewController: UIViewController, SearchPresentable, SearchViewControllable {
 
     weak var listener: SearchPresentableListener?
+    
+    init() {
+        super.init(nibName: nil, bundle: nil)
+        configureViews()
+    }
+    
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+        configureViews()
+    }
+    
+    private func configureViews() {
+        title = LocalizedString.ViewTitle.search
+        tabBarItem = UITabBarItem(title: nil, image: UIImage(systemName: "magnifyingglass"), selectedImage: UIImage(systemName: "magnifyingglass"))
+    }
 }

--- a/Hook/Hook/Search/SearchViewController.swift
+++ b/Hook/Hook/Search/SearchViewController.swift
@@ -26,6 +26,8 @@ final class SearchViewController: UIViewController, SearchPresentable, SearchVie
     
     private func configureViews() {
         title = LocalizedString.ViewTitle.search
-        tabBarItem = UITabBarItem(title: nil, image: UIImage(systemName: "magnifyingglass"), selectedImage: UIImage(systemName: "magnifyingglass"))
+        tabBarItem = UITabBarItem(title: nil,
+                                  image: UIImage(systemName: "magnifyingglass"),
+                                  selectedImage: UIImage(systemName: "magnifyingglass"))
     }
 }

--- a/Hook/Hook/Search/SearchViewController.swift
+++ b/Hook/Hook/Search/SearchViewController.swift
@@ -1,0 +1,16 @@
+//
+//  SearchViewController.swift
+//  Hook
+//
+//  Created by Yeojin Yoon on 2022/01/02.
+//
+
+import RIBs
+import UIKit
+
+protocol SearchPresentableListener: AnyObject {}
+
+final class SearchViewController: UIViewController, SearchPresentable, SearchViewControllable {
+
+    weak var listener: SearchPresentableListener?
+}

--- a/Hook/Hook/Utils/Constants/LocalizedString.swift
+++ b/Hook/Hook/Utils/Constants/LocalizedString.swift
@@ -19,4 +19,11 @@ enum LocalizedString {
     enum AlertActionTitle {
         static let ok = "OK".localized
     }
+    
+    enum ViewTitle {
+        static let browse = "Browse".localized
+        static let search = "Search".localized
+        static let favorites = "Favorites".localized
+        static let account = "Account".localized
+    }
 }

--- a/Hook/Hook/Utils/NavigationController.swift
+++ b/Hook/Hook/Utils/NavigationController.swift
@@ -1,0 +1,22 @@
+//
+//  NavigationController.swift
+//  Hook
+//
+//  Created by Yeojin Yoon on 2022/01/03.
+//
+
+import RIBs
+import UIKit
+
+final class NavigationController: ViewControllable {
+
+    let navigationController: UINavigationController
+
+    var uiviewController: UIViewController { navigationController }
+
+    init(root: ViewControllable) {
+        self.navigationController = UINavigationController(rootViewController: root.uiviewController)
+        navigationController.navigationBar.backgroundColor = .white
+        navigationController.navigationBar.prefersLargeTitles = true
+    }
+}


### PR DESCRIPTION
### 구현

| Class | Overview |
| -- | -- |
| LoggedInRouter | - `ViewableRouter`로 개선하여 해당 RIB이 뷰를 갖도록 함<br>- 자식 RIB의 뷰를 루트로 하는 `NavigationController`를 생성하고 자신의 뷰에 전달 |
| LoggedInInteractor | 활성화 시 라우터의 `attachTabs` 메서드 호출 |
| LoggedInBuilder | 자신의 뷰 및 자식 RIB의 빌더를 생성하고 라우터에 주입하여 반환 |
| LoggedInViewController | `UITabBarController`를 상속하여 탭 바 구성 |
| BrowseViewController | 둘러보기 탭의 루트 뷰 컨트롤러 |
| SearchViewController | 검색 탭의 루트 뷰 컨트롤러 |
| FavoritesViewController | 즐겨찾기 탭의 루트 뷰 컨트롤러 |
| AccountViewController | 계정 탭의 루트 뷰 컨트롤러 |
| NavigationController | 초기화 시 `ViewControllable`을 전달 받아 `UINavigationController` 생성 |

### 화면

| ko | en |
| -- | -- |
| ![](https://user-images.githubusercontent.com/93495736/147919233-3ac9a473-f48b-44ad-b11c-ba647a58b44b.PNG) | ![](https://user-images.githubusercontent.com/93495736/147919245-0ee93273-ff15-4709-95fe-dcee3eb69492.PNG) |

Closes #2