### PR TITLE
둘러보기 탭의 태그 설정 구현

### DIFF
--- a/Hook/Hook.xcodeproj/project.pbxproj
+++ b/Hook/Hook.xcodeproj/project.pbxproj
@@ -56,6 +56,7 @@
 		676AC7D5278579A60047B95F /* Tag.swift in Sources */ = {isa = PBXBuildFile; fileRef = 676AC7D4278579A60047B95F /* Tag.swift */; };
 		676AC7DD2785E6620047B95F /* TagName.swift in Sources */ = {isa = PBXBuildFile; fileRef = 676AC7DC2785E6620047B95F /* TagName.swift */; };
 		676AC7DF2785EEA80047B95F /* Array.swift in Sources */ = {isa = PBXBuildFile; fileRef = 676AC7DE2785EEA80047B95F /* Array.swift */; };
+		676D137A278DA07A003AA102 /* BrowseContent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 676D1379278DA07A003AA102 /* BrowseContent.swift */; };
 		67A2AFAD277F509E00D3A28D /* ViewControllableMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67A2AFAC277F509E00D3A28D /* ViewControllableMock.swift */; };
 		67BDEA292774C7E70031FEC1 /* LoggedOutRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67BDEA252774C7E70031FEC1 /* LoggedOutRouter.swift */; };
 		67BDEA2A2774C7E70031FEC1 /* LoggedOutViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67BDEA262774C7E70031FEC1 /* LoggedOutViewController.swift */; };
@@ -78,6 +79,11 @@
 		67CE08E12789D152006C25C1 /* TagStorageTransformer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67CE08E02789D152006C25C1 /* TagStorageTransformer.swift */; };
 		67CE08E52789ED7A006C25C1 /* ReusableView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67CE08E42789ED7A006C25C1 /* ReusableView.swift */; };
 		67CE08E72789F1C4006C25C1 /* UIView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67CE08E62789F1C4006C25C1 /* UIView.swift */; };
+		67CE08ED278B4B0D006C25C1 /* TagSettingsRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67CE08E9278B4B0D006C25C1 /* TagSettingsRouter.swift */; };
+		67CE08EE278B4B0D006C25C1 /* TagSettingsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67CE08EA278B4B0D006C25C1 /* TagSettingsViewController.swift */; };
+		67CE08EF278B4B0D006C25C1 /* TagSettingsBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67CE08EB278B4B0D006C25C1 /* TagSettingsBuilder.swift */; };
+		67CE08F0278B4B0D006C25C1 /* TagSettingsInteractor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67CE08EC278B4B0D006C25C1 /* TagSettingsInteractor.swift */; };
+		67CE08F3278C22BC006C25C1 /* TagSettingsTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67CE08F2278C22BC006C25C1 /* TagSettingsTableViewCell.swift */; };
 		67EDC91827717476003F646F /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67EDC91727717476003F646F /* AppDelegate.swift */; };
 		67EDC92127717477003F646F /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 67EDC92027717477003F646F /* Assets.xcassets */; };
 		67EDC92427717477003F646F /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 67EDC92227717477003F646F /* LaunchScreen.storyboard */; };
@@ -149,6 +155,7 @@
 		676AC7D4278579A60047B95F /* Tag.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Tag.swift; sourceTree = "<group>"; };
 		676AC7DC2785E6620047B95F /* TagName.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TagName.swift; sourceTree = "<group>"; };
 		676AC7DE2785EEA80047B95F /* Array.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Array.swift; sourceTree = "<group>"; };
+		676D1379278DA07A003AA102 /* BrowseContent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowseContent.swift; sourceTree = "<group>"; };
 		67A2AFAC277F509E00D3A28D /* ViewControllableMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewControllableMock.swift; sourceTree = "<group>"; };
 		67BDEA252774C7E70031FEC1 /* LoggedOutRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoggedOutRouter.swift; sourceTree = "<group>"; };
 		67BDEA262774C7E70031FEC1 /* LoggedOutViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoggedOutViewController.swift; sourceTree = "<group>"; };
@@ -172,6 +179,11 @@
 		67CE08E02789D152006C25C1 /* TagStorageTransformer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TagStorageTransformer.swift; sourceTree = "<group>"; };
 		67CE08E42789ED7A006C25C1 /* ReusableView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReusableView.swift; sourceTree = "<group>"; };
 		67CE08E62789F1C4006C25C1 /* UIView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIView.swift; sourceTree = "<group>"; };
+		67CE08E9278B4B0D006C25C1 /* TagSettingsRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TagSettingsRouter.swift; sourceTree = "<group>"; };
+		67CE08EA278B4B0D006C25C1 /* TagSettingsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TagSettingsViewController.swift; sourceTree = "<group>"; };
+		67CE08EB278B4B0D006C25C1 /* TagSettingsBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TagSettingsBuilder.swift; sourceTree = "<group>"; };
+		67CE08EC278B4B0D006C25C1 /* TagSettingsInteractor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TagSettingsInteractor.swift; sourceTree = "<group>"; };
+		67CE08F2278C22BC006C25C1 /* TagSettingsTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TagSettingsTableViewCell.swift; sourceTree = "<group>"; };
 		67EDC91427717476003F646F /* Hook.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Hook.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		67EDC91727717476003F646F /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		67EDC92027717477003F646F /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
@@ -287,6 +299,7 @@
 		672B2FDB2771A7D30075F348 /* Models */ = {
 			isa = PBXGroup;
 			children = (
+				676D1379278DA07A003AA102 /* BrowseContent.swift */,
 				672B2FE12771B6820075F348 /* Credential.swift */,
 				672B2FDC2771A8080075F348 /* KeychainItem.swift */,
 				672B2FE52771CFCF0075F348 /* LoginState.swift */,
@@ -400,6 +413,7 @@
 			isa = PBXGroup;
 			children = (
 				67CE08B227885606006C25C1 /* TagBar */,
+				67CE08E8278B4AEB006C25C1 /* TagSettings */,
 				67CE08AC278827BC006C25C1 /* TagRouter.swift */,
 				67CE08AE278827BC006C25C1 /* TagInteractor.swift */,
 				67CE08AD278827BC006C25C1 /* TagBuilder.swift */,
@@ -423,6 +437,26 @@
 			isa = PBXGroup;
 			children = (
 				67CE08DE2789845F006C25C1 /* TagBarCollectionViewCell.swift */,
+			);
+			path = Views;
+			sourceTree = "<group>";
+		};
+		67CE08E8278B4AEB006C25C1 /* TagSettings */ = {
+			isa = PBXGroup;
+			children = (
+				67CE08F1278C2235006C25C1 /* Views */,
+				67CE08E9278B4B0D006C25C1 /* TagSettingsRouter.swift */,
+				67CE08EC278B4B0D006C25C1 /* TagSettingsInteractor.swift */,
+				67CE08EB278B4B0D006C25C1 /* TagSettingsBuilder.swift */,
+				67CE08EA278B4B0D006C25C1 /* TagSettingsViewController.swift */,
+			);
+			path = TagSettings;
+			sourceTree = "<group>";
+		};
+		67CE08F1278C2235006C25C1 /* Views */ = {
+			isa = PBXGroup;
+			children = (
+				67CE08F2278C22BC006C25C1 /* TagSettingsTableViewCell.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -689,6 +723,7 @@
 				6736DE5C27843D38003E7321 /* TagEntity.swift in Sources */,
 				67BDEA292774C7E70031FEC1 /* LoggedOutRouter.swift in Sources */,
 				67CE08B827887303006C25C1 /* TagBarViewController.swift in Sources */,
+				67CE08ED278B4B0D006C25C1 /* TagSettingsRouter.swift in Sources */,
 				6705B5F727815C7400793CB8 /* AccountRouter.swift in Sources */,
 				676AC7DF2785EEA80047B95F /* Array.swift in Sources */,
 				672B2FE02771B6420075F348 /* CredentialRepository.swift in Sources */,
@@ -697,9 +732,11 @@
 				6705B5DD27815B3F00793CB8 /* BrowseRouter.swift in Sources */,
 				67BDEA322774C81F0031FEC1 /* LoggedInBuilder.swift in Sources */,
 				67BDEA312774C81F0031FEC1 /* LoggedInRouter.swift in Sources */,
+				676D137A278DA07A003AA102 /* BrowseContent.swift in Sources */,
 				6705B5F227815C3000793CB8 /* FavoritesInteractor.swift in Sources */,
 				676AC7D5278579A60047B95F /* Tag.swift in Sources */,
 				6705B61C2781DF3100793CB8 /* LoggedInViewController.swift in Sources */,
+				67CE08EE278B4B0D006C25C1 /* TagSettingsViewController.swift in Sources */,
 				67CE08DF2789845F006C25C1 /* TagBarCollectionViewCell.swift in Sources */,
 				67CE08B1278827BC006C25C1 /* TagInteractor.swift in Sources */,
 				6705B5F927815C7400793CB8 /* AccountBuilder.swift in Sources */,
@@ -719,8 +756,10 @@
 				6705B61E2782111D00793CB8 /* NavigationController.swift in Sources */,
 				672B2FE62771CFCF0075F348 /* LoginState.swift in Sources */,
 				67CE08B0278827BC006C25C1 /* TagBuilder.swift in Sources */,
+				67CE08F0278B4B0D006C25C1 /* TagSettingsInteractor.swift in Sources */,
 				676AC7CF2784480E0047B95F /* TagStorage+CoreDataProperties.swift in Sources */,
 				673A88A8277BF49E00A89DC7 /* String.swift in Sources */,
+				67CE08F3278C22BC006C25C1 /* TagSettingsTableViewCell.swift in Sources */,
 				6705B5E027815B3F00793CB8 /* BrowseInteractor.swift in Sources */,
 				676AC7DD2785E6620047B95F /* TagName.swift in Sources */,
 				6705B5DE27815B3F00793CB8 /* BrowseViewController.swift in Sources */,
@@ -745,6 +784,7 @@
 				67BDEA2C2774C7E70031FEC1 /* LoggedOutInteractor.swift in Sources */,
 				67CE08E12789D152006C25C1 /* TagStorageTransformer.swift in Sources */,
 				673A88B2277C05CD00A89DC7 /* Stream.swift in Sources */,
+				67CE08EF278B4B0D006C25C1 /* TagSettingsBuilder.swift in Sources */,
 				676AC7D3278574AF0047B95F /* TagRepository.swift in Sources */,
 				6705B5E827815BA300793CB8 /* SearchInteractor.swift in Sources */,
 			);

--- a/Hook/Hook/Account/AccountViewController.swift
+++ b/Hook/Hook/Account/AccountViewController.swift
@@ -10,7 +10,7 @@ import UIKit
 
 protocol AccountPresentableListener: AnyObject {}
 
-final class AccountViewController: UIViewController, AccountPresentable, AccountViewControllable {
+final class AccountViewController: UIViewController, AccountPresentable, AccountViewControllable, NavigationRootViewControllable {
     
     private enum Image {
         static let tabBarItem = UIImage(systemName: "person.crop.circle")
@@ -28,6 +28,8 @@ final class AccountViewController: UIViewController, AccountPresentable, Account
         super.init(coder: coder)
         configureViews()
     }
+    
+    func popGestureDidRecognize() {}
     
     private func configureViews() {
         title = LocalizedString.ViewTitle.account

--- a/Hook/Hook/Browse/BrowseInteractor.swift
+++ b/Hook/Hook/Browse/BrowseInteractor.swift
@@ -9,6 +9,7 @@ import RIBs
 
 protocol BrowseRouting: ViewableRouting {
     func attachTag()
+    func detachTop(for content: BrowseContent)
 }
 
 protocol BrowsePresentable: Presentable {
@@ -18,6 +19,8 @@ protocol BrowsePresentable: Presentable {
 protocol BrowseListener: AnyObject {}
 
 final class BrowseInteractor: PresentableInteractor<BrowsePresentable>, BrowseInteractable, BrowsePresentableListener {
+    
+    private var currentTopContent: BrowseContent?
 
     weak var router: BrowseRouting?
     weak var listener: BrowseListener?
@@ -34,5 +37,14 @@ final class BrowseInteractor: PresentableInteractor<BrowsePresentable>, BrowseIn
 
     override func willResignActive() {
         super.willResignActive()
+    }
+    
+    func setCurrentTopContent(_ content: BrowseContent?) {
+        currentTopContent = content
+    }
+    
+    func popGestureDidRecognize() {
+        guard let currentTopContent = currentTopContent else { return }
+        router?.detachTop(for: currentTopContent)
     }
 }

--- a/Hook/Hook/Browse/BrowseRouter.swift
+++ b/Hook/Hook/Browse/BrowseRouter.swift
@@ -14,13 +14,15 @@ protocol BrowseInteractable: Interactable, TagListener {
 
 protocol BrowseViewControllable: ViewControllable {
     func addChild(_ view: ViewControllable)
+    func push(_ view: ViewControllable)
+    func pop()
 }
 
 final class BrowseRouter: ViewableRouter<BrowseInteractable, BrowseViewControllable>, BrowseRouting {
     
     private let tag: TagBuildable
     
-    private var tagRouter: Routing?
+    private var tagRouter: TagRouting?
     
     init(interactor: BrowseInteractable,
          viewController: BrowseViewControllable,
@@ -35,5 +37,11 @@ final class BrowseRouter: ViewableRouter<BrowseInteractable, BrowseViewControlla
         let router = tag.build(withListener: interactor)
         tagRouter = router
         attachChild(router)
+    }
+    
+    func detachTop(for content: BrowseContent) {
+        if content == .tag {
+            tagRouter?.detachTop()
+        }
     }
 }

--- a/Hook/Hook/Browse/BrowseViewController.swift
+++ b/Hook/Hook/Browse/BrowseViewController.swift
@@ -8,9 +8,11 @@
 import RIBs
 import UIKit
 
-protocol BrowsePresentableListener: AnyObject {}
+protocol BrowsePresentableListener: AnyObject {
+    func popGestureDidRecognize()
+}
 
-final class BrowseViewController: UIViewController, BrowsePresentable, BrowseViewControllable {
+final class BrowseViewController: UIViewController, BrowsePresentable, BrowseViewControllable, NavigationRootViewControllable {
     
     @AutoLayout private var stackView: UIStackView = {
         let stackView = UIStackView()
@@ -36,11 +38,28 @@ final class BrowseViewController: UIViewController, BrowsePresentable, BrowseVie
         configureViews()
     }
     
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        navigationController?.setNavigationBarHidden(true, animated: true)
+    }
+    
     func addChild(_ view: ViewControllable) {
         let childViewController = view.uiviewController
         addChild(childViewController)
         stackView.addArrangedSubview(childViewController.view)
         childViewController.didMove(toParent: self)
+    }
+    
+    func push(_ view: ViewControllable) {
+        navigationController?.pushViewController(view.uiviewController, animated: true)
+    }
+    
+    func pop() {
+        navigationController?.popViewController(animated: true)
+    }
+    
+    func popGestureDidRecognize() {
+        listener?.popGestureDidRecognize()
     }
     
     private func configureViews() {

--- a/Hook/Hook/Browse/Tag/TagBar/TagBarInteractor.swift
+++ b/Hook/Hook/Browse/Tag/TagBar/TagBarInteractor.swift
@@ -15,7 +15,9 @@ protocol TagBarPresentable: Presentable {
     func update(with tags: [Tag])
 }
 
-protocol TagBarListener: AnyObject {}
+protocol TagBarListener: AnyObject {
+    func tagBarTagSettingsButtonDidTap()
+}
 
 protocol TagBarInteractorDependency {
     var tagsStream: ReadOnlyStream<[Tag]> { get }
@@ -43,6 +45,10 @@ final class TagBarInteractor: PresentableInteractor<TagBarPresentable>, TagBarIn
     
     override func willResignActive() {
         super.willResignActive()
+    }
+    
+    func tagSettingsButtonDidTap() {
+        listener?.tagBarTagSettingsButtonDidTap()
     }
     
     private func subscribeTagsStream() {

--- a/Hook/Hook/Browse/Tag/TagBar/TagBarViewController.swift
+++ b/Hook/Hook/Browse/Tag/TagBar/TagBarViewController.swift
@@ -9,7 +9,9 @@ import RIBs
 import RxSwift
 import UIKit
 
-protocol TagBarPresentableListener: AnyObject {}
+protocol TagBarPresentableListener: AnyObject {
+    func tagSettingsButtonDidTap()
+}
 
 final class TagBarViewController: UIViewController, TagBarPresentable, TagBarViewControllable {
     
@@ -22,7 +24,7 @@ final class TagBarViewController: UIViewController, TagBarPresentable, TagBarVie
         flowLayout.scrollDirection = .horizontal
         flowLayout.minimumInteritemSpacing = .zero
         let collectionView = UICollectionView(frame: .zero, collectionViewLayout: flowLayout)
-        collectionView.register(cellType: TagBarCollectionViewCell.self)
+        collectionView.register(TagBarCollectionViewCell.self)
         collectionView.showsHorizontalScrollIndicator = false
         return collectionView
     }()
@@ -33,12 +35,17 @@ final class TagBarViewController: UIViewController, TagBarPresentable, TagBarVie
         button.imageView?.contentMode = .scaleAspectFit
         button.contentHorizontalAlignment = .fill
         button.contentVerticalAlignment = .fill
-        button.tintColor = .black
+        button.tintColor = Color.tagSettingsButton
+        button.addTarget(self, action: #selector(tagSettingsButtonDidTap), for: .touchUpInside)
         return button
     }()
     
     private enum Image {
         static let tagSettingsButton = UIImage(systemName: "ellipsis")
+    }
+    
+    private enum Color {
+        static let tagSettingsButton = UIColor.black
     }
     
     private enum Metric {
@@ -93,6 +100,10 @@ final class TagBarViewController: UIViewController, TagBarPresentable, TagBarVie
             tagSettingsButton.trailingAnchor.constraint(equalTo: containerView.trailingAnchor, constant: Metric.tagSettingsButtonTrailing),
             tagSettingsButton.centerYAnchor.constraint(equalTo: containerView.centerYAnchor)
         ])
+    }
+    
+    @objc private func tagSettingsButtonDidTap() {
+        listener?.tagSettingsButtonDidTap()
     }
 }
 

--- a/Hook/Hook/Browse/Tag/TagBuilder.swift
+++ b/Hook/Hook/Browse/Tag/TagBuilder.swift
@@ -11,7 +11,7 @@ protocol TagDependency: Dependency {
     var baseViewController: BrowseViewControllable { get }
 }
 
-final class TagComponent: Component<TagDependency>, TagInteractorDependency, TagBarDependency {
+final class TagComponent: Component<TagDependency>, TagInteractorDependency, TagBarDependency, TagSettingsDependency {
     
     fileprivate var baseViewController: BrowseViewControllable { dependency.baseViewController }
     
@@ -42,8 +42,10 @@ final class TagBuilder: Builder<TagDependency>, TagBuildable {
         let interactor = TagInteractor(dependency: component)
         interactor.listener = listener
         let tagBar = TagBarBuilder(dependency: component)
+        let tagSettings = TagSettingsBuilder(dependency: component)
         return TagRouter(interactor: interactor,
                          baseViewController: component.baseViewController,
-                         tagBar: tagBar)
+                         tagBar: tagBar,
+                         tagSettings: tagSettings)
     }
 }

--- a/Hook/Hook/Browse/Tag/TagInteractor.swift
+++ b/Hook/Hook/Browse/Tag/TagInteractor.swift
@@ -10,10 +10,15 @@ import RxSwift
 
 protocol TagRouting: Routing {
     func attachTagBar()
+    func attachTagSettings()
+    func detachTagSettings()
+    func detachTop()
     func cleanupViews()
 }
 
-protocol TagListener: AnyObject {}
+protocol TagListener: AnyObject {
+    func setCurrentTopContent(_ content: BrowseContent?)
+}
 
 protocol TagInteractorDependency {
     var tagRepository: TagRepositoryType { get }
@@ -40,5 +45,17 @@ final class TagInteractor: Interactor, TagInteractable {
     override func willResignActive() {
         super.willResignActive()
         router?.cleanupViews()
+    }
+    
+    func tagBarTagSettingsButtonDidTap() {
+        router?.attachTagSettings()
+    }
+    
+    func tagSettingsBackButtonDidTap() {
+        router?.detachTagSettings()
+    }
+    
+    func reportCurrentTopContent(_ content: BrowseContent?) {
+        listener?.setCurrentTopContent(content)
     }
 }

--- a/Hook/Hook/Browse/Tag/TagRouter.swift
+++ b/Hook/Hook/Browse/Tag/TagRouter.swift
@@ -7,23 +7,28 @@
 
 import RIBs
 
-protocol TagInteractable: Interactable, TagBarListener {
+protocol TagInteractable: Interactable, TagBarListener, TagSettingsListener {
     var router: TagRouting? { get set }
     var listener: TagListener? { get set }
+    func reportCurrentTopContent(_ content: BrowseContent?)
 }
 
 final class TagRouter: Router<TagInteractable>, TagRouting {
     
     private let baseViewController: BrowseViewControllable
     private let tagBar: TagBarBuildable
+    private let tagSettings: TagSettingsBuildable
     
     private var tagBarRouter: Routing?
+    private var tagSettingsRouter: Routing?
     
     init(interactor: TagInteractable,
          baseViewController: BrowseViewControllable,
-         tagBar: TagBarBuildable) {
+         tagBar: TagBarBuildable,
+         tagSettings: TagSettingsBuildable) {
         self.baseViewController = baseViewController
         self.tagBar = tagBar
+        self.tagSettings = tagSettings
         super.init(interactor: interactor)
         interactor.router = self
     }
@@ -34,6 +39,32 @@ final class TagRouter: Router<TagInteractable>, TagRouting {
         tagBarRouter = router
         attachChild(router)
         baseViewController.addChild(router.viewControllable)
+    }
+    
+    func attachTagSettings() {
+        guard tagSettingsRouter == nil else { return }
+        let router = tagSettings.build(withListener: interactor)
+        tagSettingsRouter = router
+        attachChild(router)
+        baseViewController.push(router.viewControllable)
+        interactor.reportCurrentTopContent(.tag)
+    }
+    
+    func detachTagSettings() {
+        guard let router = tagSettingsRouter else { return }
+        baseViewController.pop()
+        detachChild(router)
+        tagSettingsRouter = nil
+        interactor.reportCurrentTopContent(nil)
+    }
+    
+    func detachTop() {
+        guard let router = children.last else { return }
+        detachChild(router)
+        if let _ = router as? TagSettingsRouting {
+            tagSettingsRouter = nil
+            interactor.reportCurrentTopContent(nil)
+        }
     }
 
     func cleanupViews() {}

--- a/Hook/Hook/Browse/Tag/TagSettings/TagSettingsBuilder.swift
+++ b/Hook/Hook/Browse/Tag/TagSettings/TagSettingsBuilder.swift
@@ -1,0 +1,38 @@
+//
+//  TagSettingsBuilder.swift
+//  Hook
+//
+//  Created by Yeojin Yoon on 2022/01/10.
+//
+
+import RIBs
+
+protocol TagSettingsDependency: Dependency {
+    var tagsStream: ReadOnlyStream<[Tag]> { get }
+}
+
+final class TagSettingsComponent: Component<TagSettingsDependency>, TagSettingsInteractorDependency {
+    
+    var tagsStream: ReadOnlyStream<[Tag]> { dependency.tagsStream }
+}
+
+// MARK: - Builder
+
+protocol TagSettingsBuildable: Buildable {
+    func build(withListener listener: TagSettingsListener) -> TagSettingsRouting
+}
+
+final class TagSettingsBuilder: Builder<TagSettingsDependency>, TagSettingsBuildable {
+    
+    override init(dependency: TagSettingsDependency) {
+        super.init(dependency: dependency)
+    }
+    
+    func build(withListener listener: TagSettingsListener) -> TagSettingsRouting {
+        let component = TagSettingsComponent(dependency: dependency)
+        let viewController = TagSettingsViewController()
+        let interactor = TagSettingsInteractor(presenter: viewController, dependency: component)
+        interactor.listener = listener
+        return TagSettingsRouter(interactor: interactor, viewController: viewController)
+    }
+}

--- a/Hook/Hook/Browse/Tag/TagSettings/TagSettingsInteractor.swift
+++ b/Hook/Hook/Browse/Tag/TagSettings/TagSettingsInteractor.swift
@@ -1,0 +1,59 @@
+//
+//  TagSettingsInteractor.swift
+//  Hook
+//
+//  Created by Yeojin Yoon on 2022/01/10.
+//
+
+import RIBs
+import RxSwift
+
+protocol TagSettingsRouting: ViewableRouting {}
+
+protocol TagSettingsPresentable: Presentable {
+    var listener: TagSettingsPresentableListener? { get set }
+    func update(with tags: [Tag])
+}
+
+protocol TagSettingsListener: AnyObject {
+    func tagSettingsBackButtonDidTap()
+}
+
+protocol TagSettingsInteractorDependency {
+    var tagsStream: ReadOnlyStream<[Tag]> { get }
+}
+
+final class TagSettingsInteractor: PresentableInteractor<TagSettingsPresentable>, TagSettingsInteractable, TagSettingsPresentableListener {
+    
+    private let dependency: TagSettingsInteractorDependency
+    
+    private var tagsStream: ReadOnlyStream<[Tag]> { dependency.tagsStream }
+    
+    weak var router: TagSettingsRouting?
+    weak var listener: TagSettingsListener?
+    
+    init(presenter: TagSettingsPresentable, dependency: TagSettingsInteractorDependency) {
+        self.dependency = dependency
+        super.init(presenter: presenter)
+        presenter.listener = self
+    }
+    
+    override func didBecomeActive() {
+        super.didBecomeActive()
+        subscribeTagsStream()
+    }
+    
+    override func willResignActive() {
+        super.willResignActive()
+    }
+    
+    func backButtonDidTap() {
+        listener?.tagSettingsBackButtonDidTap()
+    }
+    
+    private func subscribeTagsStream() {
+        tagsStream.subscribe(disposedOnDeactivate: self) { [weak self] in
+            self?.presenter.update(with: $0)
+        }
+    }
+}

--- a/Hook/Hook/Browse/Tag/TagSettings/TagSettingsRouter.swift
+++ b/Hook/Hook/Browse/Tag/TagSettings/TagSettingsRouter.swift
@@ -1,0 +1,23 @@
+//
+//  TagSettingsRouter.swift
+//  Hook
+//
+//  Created by Yeojin Yoon on 2022/01/10.
+//
+
+import RIBs
+
+protocol TagSettingsInteractable: Interactable {
+    var router: TagSettingsRouting? { get set }
+    var listener: TagSettingsListener? { get set }
+}
+
+protocol TagSettingsViewControllable: ViewControllable {}
+
+final class TagSettingsRouter: ViewableRouter<TagSettingsInteractable, TagSettingsViewControllable>, TagSettingsRouting {
+    
+    override init(interactor: TagSettingsInteractable, viewController: TagSettingsViewControllable) {
+        super.init(interactor: interactor, viewController: viewController)
+        interactor.router = self
+    }
+}

--- a/Hook/Hook/Browse/Tag/TagSettings/TagSettingsViewController.swift
+++ b/Hook/Hook/Browse/Tag/TagSettings/TagSettingsViewController.swift
@@ -1,0 +1,106 @@
+//
+//  TagSettingsViewController.swift
+//  Hook
+//
+//  Created by Yeojin Yoon on 2022/01/10.
+//
+
+import RIBs
+import RxSwift
+import UIKit
+
+protocol TagSettingsPresentableListener: AnyObject {
+    func backButtonDidTap()
+}
+
+final class TagSettingsViewController: UIViewController, TagSettingsPresentable, TagSettingsViewControllable {
+    
+    private var tags: [Tag] = []
+    
+    @AutoLayout private var tagSettingsTableView: UITableView = {
+        let tableView = UITableView()
+        tableView.register(TagSettingsTableViewCell.self)
+        tableView.tableHeaderView = UIView()
+        tableView.separatorStyle = .none
+        return tableView
+    }()
+    
+    private enum Image {
+        static let back = UIImage(systemName: "chevron.left", withConfiguration: UIImage.SymbolConfiguration(weight: .semibold))
+        static let plus = UIImage(systemName: "plus", withConfiguration: UIImage.SymbolConfiguration(weight: .semibold))
+        static let ellipsis = UIImage(systemName: "ellipsis", withConfiguration: UIImage.SymbolConfiguration(weight: .semibold))
+    }
+    
+    private enum Metric {
+        static let tagSettingsTableViewTop = CGFloat(20)
+    }
+    
+    weak var listener: TagSettingsPresentableListener?
+    
+    init() {
+        super.init(nibName: nil, bundle: nil)
+        configureViews()
+    }
+    
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+        configureViews()
+    }
+    
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        navigationController?.setNavigationBarHidden(false, animated: true)
+    }
+    
+    func update(with tags: [Tag]) {
+        self.tags = tags
+        tagSettingsTableView.reloadData()
+    }
+    
+    private func configureViews() {
+        tagSettingsTableView.dataSource = self
+        tagSettingsTableView.delegate = self
+        
+        title = LocalizedString.ViewTitle.tagSettings
+        
+        navigationItem.largeTitleDisplayMode = .never
+        navigationItem.leftBarButtonItem = UIBarButtonItem(image: Image.back, style: .done, target: self, action: #selector(backButtonDidTap))
+        navigationItem.rightBarButtonItems = [UIBarButtonItem(image: Image.ellipsis, style: .plain, target: self, action: #selector(editTagsButtonDidTap)),
+                                              UIBarButtonItem(image: Image.plus, style: .plain, target: self, action: #selector(addTagButtonDidTap))]
+        
+        hidesBottomBarWhenPushed = true
+        
+        view.backgroundColor = .white
+        view.addSubview(tagSettingsTableView)
+        
+        NSLayoutConstraint.activate([
+            tagSettingsTableView.topAnchor.constraint(equalTo: view.topAnchor, constant: Metric.tagSettingsTableViewTop),
+            tagSettingsTableView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            tagSettingsTableView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            tagSettingsTableView.bottomAnchor.constraint(equalTo: view.bottomAnchor)
+        ])
+    }
+    
+    @objc private func backButtonDidTap() {
+        listener?.backButtonDidTap()
+    }
+    
+    @objc private func addTagButtonDidTap() {}
+    
+    @objc private func editTagsButtonDidTap() {}
+}
+
+extension TagSettingsViewController: UITableViewDataSource {
+    
+    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        return tags.count
+    }
+    
+    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        let cell: TagSettingsTableViewCell = tableView.dequeueReusableCell(for: indexPath)
+        cell.configure(with: tags[indexPath.row])
+        return cell
+    }
+}
+
+extension TagSettingsViewController: UITableViewDelegate {}

--- a/Hook/Hook/Browse/Tag/TagSettings/Views/TagSettingsTableViewCell.swift
+++ b/Hook/Hook/Browse/Tag/TagSettings/Views/TagSettingsTableViewCell.swift
@@ -1,0 +1,72 @@
+//
+//  TagSettingsTableViewCell.swift
+//  Hook
+//
+//  Created by Yeojin Yoon on 2022/01/10.
+//
+
+import UIKit
+
+final class TagSettingsTableViewCell: UITableViewCell {
+    
+    @AutoLayout private var tagNameLabel: UILabel = {
+        let label = UILabel()
+        label.numberOfLines = 1
+        return label
+    }()
+    
+    private let accessoryImageView: UIImageView = {
+        let imageView = UIImageView(image: Image.accessoryView)
+        imageView.tintColor = Color.accessoryView
+        return imageView
+    }()
+    
+    private enum Image {
+        static let accessoryView = UIImage(systemName: "chevron.right",
+                                           withConfiguration: UIImage.SymbolConfiguration(weight: .semibold))
+    }
+    
+    private enum Color {
+        static let accessoryView = UIColor.lightGray
+    }
+    
+    private enum Metric {
+        static let accessoryView = CGRect(x: 0, y: 0, width: 12, height: 12)
+        static let tagNameLabelTop = CGFloat(20)
+        static let tagNameLabelLeading = CGFloat(20)
+        static let tagNameLabelTrailing = CGFloat(20)
+        static let tagNameLabelBottom = CGFloat(-20)
+    }
+    
+    override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
+        super.init(style: style, reuseIdentifier: reuseIdentifier)
+        configureViews()
+    }
+    
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+        configureViews()
+    }
+    
+    func configure(with tag: Tag) {
+        if tag.name == TagName.all {
+            tagNameLabel.text = tag.name.localized
+        } else {
+            tagNameLabel.text = tag.name
+        }
+    }
+    
+    private func configureViews() {
+        accessoryView = accessoryImageView
+        accessoryView?.bounds = Metric.accessoryView
+        
+        contentView.addSubview(tagNameLabel)
+        
+        NSLayoutConstraint.activate([
+            tagNameLabel.topAnchor.constraint(equalTo: contentView.topAnchor, constant: Metric.tagNameLabelTop),
+            tagNameLabel.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: Metric.tagNameLabelLeading),
+            tagNameLabel.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: Metric.tagNameLabelTrailing),
+            tagNameLabel.bottomAnchor.constraint(equalTo: contentView.bottomAnchor, constant: Metric.tagNameLabelBottom)
+        ])
+    }
+}

--- a/Hook/Hook/Favorites/FavoritesViewController.swift
+++ b/Hook/Hook/Favorites/FavoritesViewController.swift
@@ -10,7 +10,7 @@ import UIKit
 
 protocol FavoritesPresentableListener: AnyObject {}
 
-final class FavoritesViewController: UIViewController, FavoritesPresentable, FavoritesViewControllable {
+final class FavoritesViewController: UIViewController, FavoritesPresentable, FavoritesViewControllable, NavigationRootViewControllable {
     
     private enum Image {
         static let tabBarItem = UIImage(systemName: "bookmark")
@@ -28,6 +28,8 @@ final class FavoritesViewController: UIViewController, FavoritesPresentable, Fav
         super.init(coder: coder)
         configureViews()
     }
+    
+    func popGestureDidRecognize() {}
     
     private func configureViews() {
         title = LocalizedString.ViewTitle.favorites

--- a/Hook/Hook/LoggedIn/LoggedInRouter.swift
+++ b/Hook/Hook/LoggedIn/LoggedInRouter.swift
@@ -48,10 +48,10 @@ final class LoggedInRouter: ViewableRouter<LoggedInInteractable, LoggedInViewCon
         attachChild(favoritesRouter)
         attachChild(accountRouter)
         
-        let viewControllers = [browseRouter.viewControllable,
-                               NavigationController(root: searchRouter.viewControllable),
-                               NavigationController(root: favoritesRouter.viewControllable),
-                               NavigationController(root: accountRouter.viewControllable)]
+        let viewControllers = [NavigationController(root: browseRouter.viewControllable) ?? browseRouter.viewControllable,
+                               NavigationController(root: searchRouter.viewControllable) ?? searchRouter.viewControllable,
+                               NavigationController(root: favoritesRouter.viewControllable) ?? favoritesRouter.viewControllable,
+                               NavigationController(root: accountRouter.viewControllable) ?? accountRouter.viewControllable]
         
         viewController.setViewControllers(viewControllers)
     }

--- a/Hook/Hook/Models/BrowseContent.swift
+++ b/Hook/Hook/Models/BrowseContent.swift
@@ -1,0 +1,12 @@
+//
+//  BrowseContent.swift
+//  Hook
+//
+//  Created by Yeojin Yoon on 2022/01/11.
+//
+
+import Foundation
+
+enum BrowseContent {
+    case tag, bookmark
+}

--- a/Hook/Hook/Resources/en.lproj/Localizable.strings
+++ b/Hook/Hook/Resources/en.lproj/Localizable.strings
@@ -15,3 +15,4 @@
 "Search" = "Search";
 "Favorites" = "Favorites";
 "Account" = "Account";
+"Tag Settings" = "Tag Settings";

--- a/Hook/Hook/Resources/ko.lproj/Localizable.strings
+++ b/Hook/Hook/Resources/ko.lproj/Localizable.strings
@@ -15,3 +15,4 @@
 "Search" = "검색";
 "Favorites" = "즐겨찾기";
 "Account" = "계정";
+"Tag Settings" = "태그 설정";

--- a/Hook/Hook/Search/SearchViewController.swift
+++ b/Hook/Hook/Search/SearchViewController.swift
@@ -10,7 +10,7 @@ import UIKit
 
 protocol SearchPresentableListener: AnyObject {}
 
-final class SearchViewController: UIViewController, SearchPresentable, SearchViewControllable {
+final class SearchViewController: UIViewController, SearchPresentable, SearchViewControllable, NavigationRootViewControllable {
     
     private enum Image {
         static let tabBarItem = UIImage(systemName: "magnifyingglass")
@@ -27,6 +27,8 @@ final class SearchViewController: UIViewController, SearchPresentable, SearchVie
         super.init(coder: coder)
         configureViews()
     }
+    
+    func popGestureDidRecognize() {}
     
     private func configureViews() {
         title = LocalizedString.ViewTitle.search

--- a/Hook/Hook/Utils/Constants/LocalizedString.swift
+++ b/Hook/Hook/Utils/Constants/LocalizedString.swift
@@ -29,5 +29,6 @@ enum LocalizedString {
         static let search = "Search".localized
         static let favorites = "Favorites".localized
         static let account = "Account".localized
+        static let tagSettings = "Tag Settings".localized
     }
 }

--- a/Hook/Hook/Utils/NavigationController.swift
+++ b/Hook/Hook/Utils/NavigationController.swift
@@ -8,19 +8,21 @@
 import RIBs
 import UIKit
 
+protocol NavigationRootViewControllable: ViewControllable {
+    func popGestureDidRecognize()
+}
+
 final class NavigationController: UINavigationController, ViewControllable {
+    
+    private var root: NavigationRootViewControllable?
     
     private enum Font {
         static let navigationBarLargeTitle = UIFont.systemFont(ofSize: 26, weight: .bold)
     }
     
-    private let paragraphStyle: NSMutableParagraphStyle = {
-        let paragraphStyle = NSMutableParagraphStyle()
-        paragraphStyle.firstLineHeadIndent = 6
-        return paragraphStyle
-    }()
-    
-    init(root: ViewControllable) {
+    init?(root: ViewControllable) {
+        guard let root = root as? NavigationRootViewControllable else { return nil }
+        self.root = root
         super.init(rootViewController: root.uiviewController)
         configureViews()
     }
@@ -31,8 +33,20 @@ final class NavigationController: UINavigationController, ViewControllable {
     }
     
     private func configureViews() {
-        navigationBar.isTranslucent = false
+        navigationBar.barTintColor = .white
+        navigationBar.tintColor = .black
         navigationBar.prefersLargeTitles = true
-        navigationBar.largeTitleTextAttributes = [.font: Font.navigationBarLargeTitle, .paragraphStyle: paragraphStyle]
+        navigationBar.largeTitleTextAttributes = [.font: Font.navigationBarLargeTitle]
+        navigationBar.shadowImage = UIImage()
+        interactivePopGestureRecognizer?.delegate = self
+        interactivePopGestureRecognizer?.addTarget(self, action: #selector(popGestureDidRecognize(_:)))
+    }
+    
+    @objc private func popGestureDidRecognize(_ gesture: UIGestureRecognizer) {
+        if gesture.state == .ended {
+            root?.popGestureDidRecognize()
+        }
     }
 }
+
+extension NavigationController: UIGestureRecognizerDelegate {}

--- a/Hook/Hook/Utils/ReusableView.swift
+++ b/Hook/Hook/Utils/ReusableView.swift
@@ -16,3 +16,5 @@ extension ReusableView where Self: UIView {
 }
 
 extension UICollectionViewCell: ReusableView {}
+
+extension UITableViewCell: ReusableView {}

--- a/Hook/Hook/Utils/UIView.swift
+++ b/Hook/Hook/Utils/UIView.swift
@@ -8,12 +8,23 @@
 import UIKit
 
 extension UICollectionView {
-    func register<T: UICollectionViewCell>(cellType: T.Type) {
+    func register<T: UICollectionViewCell>(_ cellType: T.Type) {
         register(cellType, forCellWithReuseIdentifier: T.reuseIdentifier)
     }
     
     func dequeueReusableCell<T: UICollectionViewCell>(for indexPath: IndexPath) -> T {
         guard let cell = dequeueReusableCell(withReuseIdentifier: T.reuseIdentifier, for: indexPath) as? T else { return T() }
+        return cell
+    }
+}
+
+extension UITableView {
+    func register<T: UITableViewCell>(_ cellType: T.Type) {
+        register(cellType, forCellReuseIdentifier: T.reuseIdentifier)
+    }
+    
+    func dequeueReusableCell<T: UITableViewCell>(for indexPath: IndexPath) -> T {
+        guard let cell = dequeueReusableCell(withIdentifier: T.reuseIdentifier, for: indexPath) as? T else { return T() }
         return cell
     }
 }


### PR DESCRIPTION
### 구현

| RIB | Overview |
| -- | -- |
| Browse | - 자식 RIB으로부터 현재 내비게이션 스택의 최상위에 해당하는 컨텐츠 타입(태그 또는 북마크)을 전달 받아 프로퍼티에 할당<br>- 내비게이션의 pop 제스처를 인식하는 경우, 자식 RIB에 컨텐츠 타입을 전달하며 최상위에 해당하는 RIB을 detach하도록 메서드 호출 |
| Tag | - `TagSettings` RIB attach 시 내비게이션에 push하고 부모 RIB에 컨텐츠 타입 전달<br>- 내비게이션의 back 버튼을 통해 pop하는 경우, `TagSettings` RIB을 detach하고 부모 RIB에 컨텐츠 타입으로 `nil` 전달<br>- 내비게이션의 스와이프를 통해 pop하는 경우, 자식 라우터 배열의 마지막 요소를 detach하고 부모 RIB에 컨텐츠 타입으로 `nil` 전달 |
| TagSettings | 부모로부터 주입 받은 스트림을 구독하여 뷰 업데이트 |

### 화면

| ko | en |
| -- | -- |
| ![](https://user-images.githubusercontent.com/93495736/149070995-02864b45-29bf-424b-b42c-2f570dc3deb1.PNG) | ![](https://user-images.githubusercontent.com/93495736/149072216-53a77381-4ccc-4c34-9483-171115f7052c.PNG) |

Closes #7